### PR TITLE
test_SET_grid/point: include terminal commands for Windows

### DIFF
--- a/tests/test_SET_grid.py
+++ b/tests/test_SET_grid.py
@@ -39,10 +39,11 @@ pysolid.plot_solid_earth_tides_grid(tide_e, tide_n, tide_u, dt_obj,
 
 
 ## open the plotted figures
-if sys.platform == 'win32':
+if sys.platform.startswith('win'):
     os.system(out_fig)
+elif sys.platform in ['linux']:
+    os.system('display {}'.format(out_fig))
+elif sys.platform in ['darwin']:
+    os.system('open {}'.format(out_fig))
 else:
-    cmd = 'open'
-    if sys.platform in ['linux']:
-        cmd = 'display'
-    os.system('{} {}'.format(cmd, out_fig))
+    print('Unknown OS system. Check results in file: {}'.format(out_fig))

--- a/tests/test_SET_grid.py
+++ b/tests/test_SET_grid.py
@@ -39,8 +39,10 @@ pysolid.plot_solid_earth_tides_grid(tide_e, tide_n, tide_u, dt_obj,
 
 
 ## open the plotted figures
-cmd = 'open'
-if sys.platform in ['linux']:
-    cmd = 'display'
-os.system('{} {}'.format(cmd, out_fig))
-
+if sys.platform == 'win32':
+    os.system(out_fig)
+else:
+    cmd = 'open'
+    if sys.platform in ['linux']:
+        cmd = 'display'
+    os.system('{} {}'.format(cmd, out_fig))

--- a/tests/test_SET_grid.py
+++ b/tests/test_SET_grid.py
@@ -39,11 +39,11 @@ pysolid.plot_solid_earth_tides_grid(tide_e, tide_n, tide_u, dt_obj,
 
 
 ## open the plotted figures
-if sys.platform.startswith('win'):
-    os.system(out_fig)
-elif sys.platform in ['linux']:
+if sys.platform in ['linux']:
     os.system('display {}'.format(out_fig))
 elif sys.platform in ['darwin']:
     os.system('open {}'.format(out_fig))
+elif sys.platform.startswith('win'):
+    os.system(out_fig)
 else:
     print('Unknown OS system. Check results in file: {}'.format(out_fig))

--- a/tests/test_SET_point.py
+++ b/tests/test_SET_point.py
@@ -33,8 +33,10 @@ pysolid.plot_solid_earth_tides_point(dt_out, tide_e, tide_n, tide_u, lalo=[lat, 
                                      out_fig=out_fig, display=False)
 
 ## open the plotted figures
-cmd = 'open'
-if sys.platform in ['linux']:
-    cmd = 'display'
-os.system('{} {}'.format(cmd, out_fig))
-
+if sys.platform == 'win32':
+    os.system(out_fig)
+else:
+    cmd = 'open'
+    if sys.platform in ['linux']:
+        cmd = 'display'
+    os.system('{} {}'.format(cmd, out_fig))

--- a/tests/test_SET_point.py
+++ b/tests/test_SET_point.py
@@ -33,10 +33,12 @@ pysolid.plot_solid_earth_tides_point(dt_out, tide_e, tide_n, tide_u, lalo=[lat, 
                                      out_fig=out_fig, display=False)
 
 ## open the plotted figures
-if sys.platform == 'win32':
+if sys.platform in ['linux']:
+    os.system('display {}'.format(out_fig))
+elif sys.platform in ['darwin']:
+    os.system('open {}'.format(out_fig))
+elif sys.platform.startswith('win'):
     os.system(out_fig)
 else:
-    cmd = 'open'
-    if sys.platform in ['linux']:
-        cmd = 'display'
-    os.system('{} {}'.format(cmd, out_fig))
+    print('Unknown OS system. Check results in file: {}'.format(out_fig))
+


### PR DESCRIPTION
This addresses the issue where the test will raise an error in a Windows environment when trying to open the output figure using terminal commands.