### PR TITLE
circleci: bugfix2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
             export PYTHONUNBUFFERED=1
             # setup environment variable
             export PYTHONPATH=${PYTHONPATH}:${HOME}/tools/PySolid
+            export PATH=${CONDA_PREFIX}/bin:${PATH}
             # install dependencies
             source activate root
             mamba install --verbose --yes --file ${HOME}/tools/PySolid/requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,9 @@ jobs:
       - run:
           name: Test
           command: |
+            # setup environment variables
             export PYTHONPATH=${PYTHONPATH}:${HOME}/tools/PySolid
+            export PATH=${CONDA_PREFIX}/bin:${PATH}
+            # run tests
             python ${HOME}/tools/PySolid/tests/test_SET_point.py
             python ${HOME}/tools/PySolid/tests/test_SET_grid.py


### PR DESCRIPTION
Try to fix the following error:

```bash
#!/bin/bash -eo pipefail
export PYTHONUNBUFFERED=1
# setup environment variable
export PYTHONPATH=${PYTHONPATH}:${HOME}/tools/PySolid
# install dependencies
source activate root
mamba install --verbose --yes --file ${HOME}/tools/PySolid/requirements.txt
# compile Fortran code
cd ${HOME}/tools/PySolid/pysolid
f2py -c -m solid solid.for

/bin/bash: line 4: activate: No such file or directory

Exited with code exit status 1
CircleCI received exit code 1
```