### PR TITLE
solid.for: close the file explicitly for windows OS

### DIFF
--- a/pysolid/solid.for
+++ b/pysolid/solid.for
@@ -165,6 +165,7 @@
         write(*,'(a)') 'Mild Warning -- time crossed leap second table'
         write(*,'(a)') '  boundaries.  Boundary edge value used instead'
       endif
+      close(lout)
 
       go to 99
    98 write(*,'(a)') 'Check arguments.'
@@ -307,6 +308,7 @@
         write(*,'(a)') 'Mild Warning -- time crossed leap second table'
         write(*,'(a)') '  boundaries.  Boundary edge value used instead'
       endif
+      close(lout)
 
       go to 99
    98 write(*,'(a)') 'Check arguments.'


### PR DESCRIPTION
This PR adds the change discussed in #12. 

+ `solid.for`: close the file explicitly for windows OS as reported by @pbrotoisworo.