### PR TITLE
tests: Modify out figure paths from relative to absolute paths

### DIFF
--- a/tests/test_SET_grid.py
+++ b/tests/test_SET_grid.py
@@ -34,7 +34,7 @@ atr = {
  tide_u) = pysolid.calc_solid_earth_tides_grid(dt_obj, atr, verbose=True)
 
 # plot
-out_fig = os.path.join(os.path.dirname(__file__), 'test_SET_grid.png')
+out_fig = os.path.abspath(os.path.join(os.path.dirname(__file__), 'test_SET_grid.png'))
 pysolid.plot_solid_earth_tides_grid(tide_e, tide_n, tide_u, dt_obj,
                                     out_fig=out_fig, display=False)
 

--- a/tests/test_SET_point.py
+++ b/tests/test_SET_point.py
@@ -29,7 +29,7 @@ dt_obj1 = dt.datetime(2020, 12, 31, 2, 0, 0)
  tide_u) = pysolid.calc_solid_earth_tides_point(lat, lon, dt_obj0, dt_obj1, verbose=False)
 
 # plot
-out_fig = os.path.join(os.path.dirname(__file__), 'test_SET_point.png')
+out_fig = os.path.abspath(os.path.join(os.path.dirname(__file__), 'test_SET_point.png'))
 pysolid.plot_solid_earth_tides_point(dt_out, tide_e, tide_n, tide_u, lalo=[lat, lon],
                                      out_fig=out_fig, display=False)
 


### PR DESCRIPTION
Addresses bug when trying to open figures with relative paths as seen in #15.

Output figure path is modified from relative path to absolute path using `os.path.abspath`.