### PR TITLE
automate PyPI publishing with GitHub Actions

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,57 @@
+# link: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: publish distributions 📦 to PyPI and TestPyPI
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+
+jobs:
+  build-n-publish:
+    if: github.repository_owner == 'insarlab'
+
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish developed version 📦 to Test PyPI
+      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+        skip_existing: false
+        verbose: true
+
+    - name: Publish released version 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        verbose: true

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 # Author: Zhang Yunjun, Jan 2021
 # Copyright 2020, by the California Institute of Technology.
+# Note by Yunjun, Oct 2022: "pip install pysolid" does not work,
+#   because a Fortran compiler is required but not available via pip
 
 
 # always prefer setuptools over distutils
@@ -7,13 +9,16 @@ import setuptools
 from numpy.distutils.core import setup, Extension
 
 # Grab from version.py file: version
+# Note by Yunjun, Oct 2022: do not use sys.path.append() to import pysolid because
+# pysolid.__init__ requires the pysolid.solid sub-module, which is not compiled yet.
 with open("src/pysolid/version.py", "r") as f:
     lines = f.readlines()
     line = [line for line in lines if line.strip().startswith("Tag(")][0].strip()
     version = line.replace("'",'"').split('"')[1]
 
-# specify fortran extensions to build with numpy.f2py
-solid_ext = Extension(name='pysolid.solid', sources=['src/pysolid/solid.for'])
+# Grab from README file: long_description
+with open("README.md", "r") as f:
+    long_description = f.read()
 
 setup(
     name='pysolid',
@@ -21,6 +26,8 @@ setup(
     description="A Python wrapper for solid to compute solid Earth tides",
     url="https://github.com/insarlab/PySolid",
     download_url=("https://github.com/insarlab/PySolid/archive/v{}.tar.gz".format(version)),
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author="Zhang Yunjun, Dennis Milbert",
     author_email="yunjunzgeo@gmail.com",
     license="GPL-3.0-or-later",
@@ -46,7 +53,9 @@ setup(
     package_dir={"": "src"},                   # tell distutils packages are under src
 
     # build fortran deps with numpy.f2py
-    ext_modules=[solid_ext],
+    ext_modules=[
+        Extension(name='pysolid.solid', sources=['src/pysolid/solid.for']),
+    ],
 
     # dependencies
     python_requires=">=3.6",

--- a/src/pysolid/__init__.py
+++ b/src/pysolid/__init__.py
@@ -1,5 +1,5 @@
 # get version info
-from pysolid.version import release_version as __version__
+from pysolid.version import version as __version__
 
 # top-level functions
 from pysolid.grid import (

--- a/src/pysolid/version.py
+++ b/src/pysolid/version.py
@@ -4,7 +4,11 @@
 
 
 import collections
+import os
+import subprocess
 
+
+###########################################################################
 # release history
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
@@ -17,5 +21,41 @@ release_history = (
 )
 
 # latest release
-release_version = 'v{}'.format(release_history[0].version)
+release_version = release_history[0].version
 release_date = release_history[0].date
+
+# get development version info
+def get_version_info():
+    """Grab version and date of the latest commit from a git repository"""
+    # go to the repository directory
+    dir_orig = os.getcwd()
+    os.chdir(os.path.dirname(os.path.dirname(__file__)))
+
+    try:
+        # grab from git cmd
+        cmd = "git describe --tags"
+        version = subprocess.check_output(cmd.split(), stderr=subprocess.DEVNULL)
+        version = version.decode('utf-8').strip()[1:]
+
+        # if there are new commits after the latest release
+        if '-' in version:
+            version, num_commit = version.split('-')[:2]
+            version += f'-{num_commit}'
+
+        cmd = "git log -1 --date=short --format=%cd"
+        date = subprocess.check_output(cmd.split(), stderr=subprocess.DEVNULL)
+        date = date.decode('utf-8').strip()
+
+    except:
+        # use the latest release version/date
+        version = release_version
+        date = release_date
+
+    # go back to the original directory
+    os.chdir(dir_orig)
+    return version, date
+
+
+###########################################################################
+version, version_date = get_version_info()
+


### PR DESCRIPTION
+ copy `.github/workflows/publish-to-test-pypi.yml` from mintpy (https://github.com/insarlab/MintPy/pull/827), since pysolid could now be uploaded to PyPI (https://github.com/pypa/pypi-support/issues/2166).

+ version.py:
   - copy get_version_info() from mintpy, to grab the individual version number for each commit
   - use version number with prefix "v"

+ setup.py:
   - grab version from version.py
   - grab long_description from README file