### PR TITLE
wrap up for version 0.2.3

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -8,6 +8,12 @@ on:
     tags:
       - v*
 
+# activate miniconda environment
+# link: https://github.com/marketplace/actions/provision-with-micromamba#IMPORTANT
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   build-n-publish:
     if: github.repository_owner == 'insarlab'
@@ -24,6 +30,12 @@ jobs:
       with:
         python-version: "3.10"
 
+    # link: https://github.com/marketplace/actions/provision-with-micromamba
+    - name: Install Conda environment with Micromamba
+      uses: mamba-org/provision-with-micromamba@main
+      with:
+        environment-file: environment.yml
+
     - name: Install pypa/build
       run: >-
         python -m
@@ -36,9 +48,12 @@ jobs:
         python -m
         build
         --sdist
-        --wheel
+        --no-isolation    # not install in an isolated environment
         --outdir dist/
         .
+        # skip due to the bad request error from pypi:
+        # binary wheel has an unsupported platform tag 'linux_x86_64'
+        #--wheel
 
     - name: Publish developed version 📦 to Test PyPI
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,17 @@
 #   because a Fortran compiler is required but not available via pip
 
 
+import os
+import sys
+
 # always prefer setuptools over distutils
 import setuptools
 from numpy.distutils.core import setup, Extension
 
-# Grab from version.py file: version
-# Note by Yunjun, Oct 2022: do not use sys.path.append() to import pysolid because
-# pysolid.__init__ requires the pysolid.solid sub-module, which is not compiled yet.
-with open("src/pysolid/version.py", "r") as f:
-    lines = f.readlines()
-    line = [line for line in lines if line.strip().startswith("Tag(")][0].strip()
-    version = line.replace("'",'"').split('"')[1]
+# Grab from pysolid.version: version
+# link: https://stackoverflow.com/questions/53648900
+sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
+from pysolid.version import version
 
 # Grab from README file: long_description
 with open("README.md", "r") as f:

--- a/src/pysolid/grid.py
+++ b/src/pysolid/grid.py
@@ -11,18 +11,11 @@
 #   pysolid.calc_solid_earth_tides_grid()
 
 
-import os
-import numpy as np
 import datetime as dt
-from skimage.transform import resize
+import os
 
-try:
-    from pysolid.solid import solid_grid
-except ImportError:
-    msg = "Cannot import name 'solid' from 'pysolid'!"
-    msg += '\n    Maybe solid.for is NOT compiled yet.'
-    msg += '\n    Check instruction at: https://github.com/insarlab/PySolid.'
-    raise ImportError(msg)
+import numpy as np
+from skimage.transform import resize
 
 
 ##################################  Earth tides - grid mode  ###################################
@@ -49,6 +42,14 @@ def calc_solid_earth_tides_grid(dt_obj, atr, step_size=1e3, display=False, verbo
     Examples:   atr = readfile.read_attribute('geo_velocity.h5')
                 tide_e, tide_n, tide_u = calc_solid_earth_tides_grid('20180219', atr)
     """
+    try:
+        from pysolid.solid import solid_grid
+    except ImportError:
+        msg = "Cannot import name 'solid' from 'pysolid'!"
+        msg += '\n    Maybe solid.for is NOT compiled yet.'
+        msg += '\n    Check instruction at: https://github.com/insarlab/PySolid.'
+        raise ImportError(msg)
+
     vprint = print if verbose else lambda *args, **kwargs: None
 
     # location

--- a/src/pysolid/point.py
+++ b/src/pysolid/point.py
@@ -11,20 +11,13 @@
 #   pysolid.calc_solid_earth_tides_point()
 
 
-import os
 import collections
 import datetime as dt
-import numpy as np
-from scipy import signal
-from matplotlib import pyplot as plt, ticker, dates as mdates
+import os
 
-try:
-    from pysolid.solid import solid_point
-except ImportError:
-    msg = "Cannot import name 'solid' from 'pysolid'!"
-    msg += '\n    Maybe solid.for is NOT compiled yet.'
-    msg += '\n    Check instruction at: https://github.com/insarlab/PySolid.'
-    raise ImportError(msg)
+import numpy as np
+from matplotlib import pyplot as plt, ticker, dates as mdates
+from scipy import signal
 
 
 ## Tidal constituents
@@ -168,6 +161,13 @@ def calc_solid_earth_tides_point_per_day(lat, lon, date_str, step_sec=60):
                  tide_n,
                  tide_u) = calc_solid_earth_tides_point_per_day(34.0, -118.0, '20180219')
     """
+    try:
+        from pysolid.solid import solid_point
+    except ImportError:
+        msg = "Cannot import name 'solid' from 'pysolid'!"
+        msg += '\n    Maybe solid.for is NOT compiled yet.'
+        msg += '\n    Check instruction at: https://github.com/insarlab/PySolid.'
+        raise ImportError(msg)
 
     ## calc solid Earth tides and write to text file
     txt_file = os.path.abspath('solid.txt')

--- a/src/pysolid/solid.for
+++ b/src/pysolid/solid.for
@@ -1549,9 +1549,9 @@
 ***** http://www.csgnetwork.com/julianmodifdateconv.html
 
       implicit double precision(a-h,o-z)
-      !*** upper limit, leap second table, 2022dec28
+      !*** upper limit, leap second table, 2023jun28
       !*** lower limit, leap second table, 1972jan01
-      parameter(MJDUPPER=59941)
+      parameter(MJDUPPER=60123)
       parameter(MJDLOWER=41317)
 
       !*** leap second table limit flag
@@ -1632,7 +1632,7 @@
 ***** other leap second references at:
 ***** http://hpiers.obspm.fr/eoppc/bul/bulc/Leap_Second_History.dat
 ***** http://hpiers.obspm.fr/eoppc/bul/bulc/bulletinc.dat
-***** File expires on 28 December 2022
+***** File expires on 28 June 2023
 
 *** test against newest leaps first
 

--- a/src/pysolid/version.py
+++ b/src/pysolid/version.py
@@ -12,6 +12,7 @@ import subprocess
 # release history
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
+    Tag('0.2.3', '2022-10-23'),
     Tag('0.2.2', '2022-07-20'),
     Tag('0.2.1', '2022-01-05'),
     Tag('0.2.0', '2021-11-10'),


### PR DESCRIPTION
+ version: add Tab for version 0.2.3

+ solid.for: update the file expiration date of the leap second table to 2023-Jun-28 as no leap second will be introduced at the end of Dec 2022, based on Bulletin C 64 (https://hpiers.obspm.fr/eoppc/bul/bulc/bulletinc.64)

+ bugfix for publish-to-pypi:
   - grid/point: move solid_grid/point import into sub-functions, to support grabbing pysolid.version without a compiled solid.for
   - setup: switch to use pysolid.version to grab the dev version number
   - publish-to-pypi: add mamba env + skip wheel build/upload