### PR TITLE
version 0.2.4: move scipy/matplotlib/skimage into sub-func

### DIFF
--- a/src/pysolid/grid.py
+++ b/src/pysolid/grid.py
@@ -15,7 +15,6 @@ import datetime as dt
 import os
 
 import numpy as np
-from skimage.transform import resize
 
 
 ##################################  Earth tides - grid mode  ###################################
@@ -42,6 +41,7 @@ def calc_solid_earth_tides_grid(dt_obj, atr, step_size=1e3, display=False, verbo
     Examples:   atr = readfile.read_attribute('geo_velocity.h5')
                 tide_e, tide_n, tide_u = calc_solid_earth_tides_grid('20180219', atr)
     """
+    from skimage.transform import resize
     try:
         from pysolid.solid import solid_grid
     except ImportError:

--- a/src/pysolid/point.py
+++ b/src/pysolid/point.py
@@ -16,8 +16,6 @@ import datetime as dt
 import os
 
 import numpy as np
-from matplotlib import pyplot as plt, ticker, dates as mdates
-from scipy import signal
 
 
 ## Tidal constituents
@@ -205,6 +203,8 @@ def calc_solid_earth_tides_point_per_day(lat, lon, date_str, step_sec=60):
 def plot_solid_earth_tides_point(dt_out, tide_e, tide_n, tide_u, lalo=None,
                                  out_fig=None, save=False, display=True):
     """Plot the solid Earth tides at one point."""
+    from matplotlib import pyplot as plt, dates as mdates
+
     # plot
     fig, axs = plt.subplots(nrows=3, ncols=1, figsize=[6, 4], sharex=True)
     for ax, data, label in zip(axs.flatten(),
@@ -247,6 +247,9 @@ def plot_power_spectral_density4tides(tide_ts, sample_spacing, out_fig=None, fig
     """Plot the power spectral density (PSD) of tides time-series.
     Note: for accurate PSD analysis, a long time-series, e.g. one year, is recommended.
     """
+    from matplotlib import pyplot as plt, ticker
+    from scipy import signal
+
     ## calc PSD
     freq, psd = signal.periodogram(tide_ts, fs=1/sample_spacing, scaling='density')
     # get rid of zero in the first element

--- a/src/pysolid/version.py
+++ b/src/pysolid/version.py
@@ -12,6 +12,7 @@ import subprocess
 # release history
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
+    Tag('0.2.4', '2022-10-24'),
     Tag('0.2.3', '2022-10-23'),
     Tag('0.2.2', '2022-07-20'),
     Tag('0.2.1', '2022-01-05'),


### PR DESCRIPTION
+ move scipy/matplotlib/skimage into the sub-functions, to avoid adding them to the requirements/host in the conda-forge recipe, as the latter is recommended by conda-forge guideline

+ add release Tag for version 0.2.4