### PR TITLE
publish2pypi: fix the GH action version

### DIFF
--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -84,7 +84,7 @@ jobs:
           path: dist
 
       - name: Publish developed version 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.5.0
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -93,7 +93,7 @@ jobs:
           verbose: true
 
       - name: Publish released version 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.5.0
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           user: __token__


### PR DESCRIPTION
An attempt to fix the `upload_pypi` GitHub action error (https://github.com/insarlab/PySolid/actions/runs/3389862941/jobs/5633942424):

```
Error: Unable to resolve action `pypa/gh-action-pypi-publish@release%2Fv1.5.0`, unable to find version `release/v1.5.0`
```