### PR TITLE
update solid.for for explicit arg types + attempt to fix pip install by pin setuptools/numpy

### DIFF
--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build Python 🐍 wheels on ${{ matrix.os }}
+    name: Build 🐍 wheels 📦 on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -59,7 +59,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   build_sdist:
-    name: Build Python 🐍 source distribution
+    name: Build 🐍 source distribution 📦
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -74,6 +74,7 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
+    name: Upload 📦 to PyPI
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: github.repository_owner == 'insarlab' && github.event_name == 'push'

--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -47,6 +47,7 @@ jobs:
         env:
           # Disable building for PyPy and 32bit.
           CIBW_SKIP: pp* *-win32 *-manylinux_i686
+          CIBW_ENVIRONMENT_MACOS: SETUPTOOLS_USE_DISTUTILS=stdlib
           # Package the DLL dependencies in the wheel for windows (done by default for the other platforms).
           # delvewheel cannot mangle the libraries, stripping does not work.
           CIBW_BEFORE_BUILD_WINDOWS: pip install delvewheel

--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -47,6 +47,7 @@ jobs:
         env:
           # Disable building for PyPy and 32bit.
           CIBW_SKIP: pp* *-win32 *-manylinux_i686
+          # Fix error for python 3.11 on macOS
           CIBW_ENVIRONMENT_MACOS: SETUPTOOLS_USE_DISTUTILS=stdlib
           # Package the DLL dependencies in the wheel for windows (done by default for the other platforms).
           # delvewheel cannot mangle the libraries, stripping does not work.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Language](https://img.shields.io/badge/python-3.6%2B-blue.svg)](https://www.python.org/)
+[![Language](https://img.shields.io/badge/python-3.8%2B-blue.svg)](https://www.python.org/)
 [![CircleCI](https://img.shields.io/circleci/build/github/insarlab/PySolid.svg?logo=circleci&label=test)](https://circleci.com/gh/insarlab/PySolid)
 [![Version](https://img.shields.io/github/v/release/insarlab/PySolid?color=green)](https://github.com/insarlab/PySolid/releases)
 [![License](https://img.shields.io/badge/license-GPLv3+-yellow.svg)](https://github.com/insarlab/PySolid/blob/main/LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<60.0", "setuptools_scm[toml]>=6.2", "oldest-supported-numpy", "wheel"]
+requires = ["setuptools<60.0", "setuptools_scm[toml]>=6.2", "numpy<1.23.0", "wheel"]
 
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<60.0", "setuptools_scm[toml]>=6.2", "numpy", "wheel"]
+requires = ["setuptools<60.0", "setuptools_scm[toml]>=6.2", "oldest-supported-numpy", "wheel"]
 
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysolid"
+description = "A Python wrapper for solid to compute solid Earth tides"
 authors = [
     {name="Zhang Yunjun", email="yunjunzgeo@gmail.com"},
     {name="Dennis Milbert"},
 ]
-description = "A Python wrapper for solid to compute solid Earth tides"
 readme = "README.md"
 requires-python = ">=3.8"
 keywords = ["solid Earth tides", "deformation", "geodesy", "geophysics"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = ["setuptools<60.0", "setuptools_scm[toml]>=6.2", "numpy<1.23.0", "wheel"]
-
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2", "numpy", "wheel"]
+requires = ["setuptools<60.0", "setuptools_scm[toml]>=6.2", "numpy", "wheel"]
 
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ import setuptools
 from numpy.distutils.core import setup, Extension
 
 setup(
+    # avoid UNKNOWN name in setuptools<60, the latter is required for numpy.distutils
+    name='pysolid',
     # fortran extensions to build with numpy.f2py
     ext_modules=[
         Extension(name='pysolid.solid', sources=['src/pysolid/solid.for']),

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,20 @@ import setuptools
 from numpy.distutils.core import setup, Extension
 
 setup(
-    # avoid UNKNOWN name in setuptools<60, the latter is required for numpy.distutils
+    ## add the following redundant setup for setuptools<60, the latter is required for numpy.distutils
     name='pysolid',
-    # fortran extensions to build with numpy.f2py
+
+    # package discovery
+    packages=setuptools.find_packages("src"),  # include all packages under src
+    package_dir={"": "src"},                   # tell distutils packages are under src
+
+    # data files
+    include_package_data=True,
+    package_data={
+        "pysolid": ["solid.for"],
+    },
+
+    ## fortran extensions to build with numpy.f2py
     ext_modules=[
         Extension(name='pysolid.solid', sources=['src/pysolid/solid.for']),
     ],

--- a/src/pysolid/solid.for
+++ b/src/pysolid/solid.for
@@ -361,7 +361,8 @@
 
       implicit double precision(a-h,o-z)
       double precision xsta(3),xsun(3),xmon(3),dxtide(3),xcorsta(3)
-      double precision h20,l20,h3,l3,h2,l2
+      double precision h20,l20,h3,l3,h2,l2,fmjd
+      integer mjd
       double precision mass_ratio_sun,mass_ratio_moon
       logical lflag,leapflag
       !*** leap second table limit flag
@@ -533,8 +534,8 @@
 *** output: xcorsta
 
       implicit double precision (a-h,o-z)
-      dimension xsta(3),xsun(3),xmon(3),xcorsta(3)
-      double precision l1,l1d,l1sd
+      double precision xsta(3),xsun(3),xmon(3),xcorsta(3)
+      double precision l1,l1d,l1sd,fac2sun,fac2mon
       data l1d/0.0012d0/,l1sd/0.0024d0/
 
       rsta=enorm8(xsta)
@@ -593,7 +594,7 @@
 
       implicit double precision (a-h,o-z)
       double precision xsta(3),xcorsta(3),datdi(9,31)
-      double precision deg2rad
+      double precision deg2rad, fhr, t
       data deg2rad/0.017453292519943295769d0/
 
 *** note, following table is derived from dehanttideinelMJD.f (2000oct30 16:10)
@@ -750,7 +751,7 @@
       subroutine step2lon(xsta,fhr,t,xcorsta)
 
       implicit double precision (a-h,o-z)
-      double precision deg2rad
+      double precision deg2rad,fhr,t
       double precision xsta(3),xcorsta(3),datdi(9,5)
       data deg2rad/0.017453292519943295769d0/
 
@@ -836,7 +837,8 @@
 *** output: xcorsta
 
       implicit double precision (a-h,o-z)
-      dimension xsta(3),xsun(3),xmon(3),xcorsta(3)
+      double precision xsta(3),xsun(3),xmon(3),xcorsta(3)
+      double precision fac2sun,fac2mon
       data dhi/-0.0025d0/,dli/-0.0007d0/
 
       rsta=enorm8(xsta)
@@ -878,7 +880,8 @@
 *** output: xcorsta
 
       implicit double precision (a-h,o-z)
-      dimension xsta(3),xsun(3),xmon(3),xcorsta(3)
+      double precision xsta(3),xsun(3),xmon(3),xcorsta(3)
+      double precision fac2sun, fac2mon
       data dhi/-0.0022d0/,dli/-0.0007d0/
 
       rsta=enorm8(xsta)
@@ -923,6 +926,7 @@
 
       implicit double precision (a-h,o-z)
       double precision x(3),y(3)
+      double precision r1,r2,scal
 
       r1=dsqrt(x(1)*x(1) + x(2)*x(2) + x(3)*x(3))
       r2=dsqrt(y(1)*y(1) + y(2)*y(2) + y(3)*y(3))
@@ -969,7 +973,9 @@
 *** section 3.2, pg. 38-39  routine MiniMoon
 
       implicit double precision(a-h,o-z)
-      dimension rm(3)
+      double precision rm(3)
+      integer mjd
+      double precision fmjd
       logical lflag,leapflag
       !*** leap second table limit flag
       !*** leap second table limit flag
@@ -1105,6 +1111,8 @@
 *** section 2.3.1, pg. 33
 
       implicit double precision(a-h,o-z)
+      integer mjd
+      double precision fmjd,ghar
       common/stuff/rad,pi,pi2
 
 *** need UTC to get sidereal time ("astronomy on the personal computer", 4th ed)
@@ -1156,7 +1164,9 @@
 *** section 3.2, pg. 39  routine MiniSun
 
       implicit double precision(a-h,o-z)
-      dimension rs(3)
+      double precision rs(3)
+      double precision fmjd
+      integer mjd
       logical lflag,leapflag
       !*** leap second table limit flag
       !*** leap second table limit flag
@@ -1239,6 +1249,7 @@
 *** determine range,azimuth,vertical angle from local horizon coord.
 
       implicit double precision(a-h,o-z)
+      double precision u,v,w,ra,az,va
       
       s2=u*u+v*v
       r2=s2+w*w
@@ -1257,6 +1268,7 @@
 *** convert geodetic lat, long, ellip ht. to x,y,z
 
       implicit double precision(a-h,o-z)
+      double precision gla,glo,eht,x,y,z
       common/comgrs/a,e2
 
       sla=dsin(gla)
@@ -1278,6 +1290,7 @@
 *** compute a geodetic h cartesian sys   (u,v,w)
 
       implicit double precision(a-h,o-z)
+      double precision gla,glo,u,v,w,x,y,z
 
       sb=dsin(gla)
       cb=dcos(gla)
@@ -1297,6 +1310,7 @@
 *** x,y,z transformed into u,v,w
 
       implicit double precision(a-h,o-z)
+      double precision theta,x,y,z,u,v,w
       
       s=dsin(theta)
       c=dcos(theta)
@@ -1314,6 +1328,7 @@
 *** x,y,z transformed into u,v,w
 
       implicit double precision(a-h,o-z)
+      double precision theta,x,y,z,u,v,w
       
       s=dsin(theta)
       c=dcos(theta)
@@ -1334,7 +1349,7 @@
 *** allows single number expression of time in seconds w.r.t. mjd0
 
       implicit double precision(a-h,o-z)
-      integer y
+      integer y,iyr,imo,idy
       save /mjdoff/
       common/mjdoff/mjd0
 
@@ -1369,7 +1384,8 @@
 *** adapted from civmjd()
 
       implicit double precision(a-h,o-z)
-      integer y
+      integer y,iyr,imo,idy,ihr,imn
+      double precision sec,tsec
       save /mjdoff/
       common/mjdoff/mjd0
 
@@ -1402,6 +1418,8 @@
 *** adapted from mjdciv()
 
       implicit double precision(a-h,o-z)
+      integer iyr,imo,idy,ihr,imn
+      double precision sec,tsec
       save /mjdoff/
       common/mjdoff/mjd0
 
@@ -1445,7 +1463,8 @@
 *** operation confirmed against table 3.3 values on pg.34
 
       implicit double precision(a-h,o-z)
-      integer y
+      integer y,iyr,imo,idy,ihr,imn,mjd
+      double precision sec,fmjd
 
       if(iyr.lt.1900) stop 34588
 
@@ -1476,6 +1495,8 @@
 *** operation confirmed for leap years (incl. year 2000)
 
       implicit double precision(a-h,o-z)
+      integer mjd,iyr,imo,idy,ihr,imn
+      double precision fmjd,sec
 
       rjd=mjd+fmjd+2400000.5d0
       ia=(rjd+0.5d0)
@@ -1510,6 +1531,7 @@
 *** convert utc (sec) to terrestrial time (sec)
 
       implicit double precision(a-h,o-z)
+      double precision tutc
 
       ttai   = utc2tai(tutc)
       utc2ttt= tai2tt(ttai)
@@ -1522,6 +1544,7 @@
 *** convert gps time (sec) to terrestrial time (sec)
 
       implicit double precision(a-h,o-z)
+      double precision tgps
 
       ttai   = gps2tai(tgps)
       gps2ttt= tai2tt(ttai)
@@ -1534,6 +1557,7 @@
 *** convert utc (sec) to tai (sec)
 
       implicit double precision(a-h,o-z)
+      double precision tutc
 
       utc2tai = tutc - getutcmtai(tutc)
 
@@ -1549,6 +1573,7 @@
 ***** http://www.csgnetwork.com/julianmodifdateconv.html
 
       implicit double precision(a-h,o-z)
+      double precision tsec
       !*** upper limit, leap second table, 2023jun28
       !*** lower limit, leap second table, 1972jan01
       parameter(MJDUPPER=60123)
@@ -1741,6 +1766,7 @@
 *** convert tai (sec) to terrestrial time (sec)
 
       implicit double precision(a-h,o-z)
+      double precision tai2tt
 
 ***** http://tycho.usno.navy.mil/systime.html
       tai2tt = ttai + 32.184d0
@@ -1753,6 +1779,7 @@
 *** convert gps time (sec) to tai (sec)
 
       implicit double precision(a-h,o-z)
+      double precision tgps
 
 ***** http://leapsecond.com/java/gpsclock.htm
 ***** http://tycho.usno.navy.mil/leapsec.html

--- a/src/pysolid/solid.for
+++ b/src/pysolid/solid.for
@@ -1766,7 +1766,7 @@
 *** convert tai (sec) to terrestrial time (sec)
 
       implicit double precision(a-h,o-z)
-      double precision tai2tt
+      double precision ttai
 
 ***** http://tycho.usno.navy.mil/systime.html
       tai2tt = ttai + 32.184d0


### PR DESCRIPTION
f2py compiler for py311+ on OS-X scans code explicitly for data types of arguments in functions and subroutines. Implicit declarations are not interpreted, causing wheel builds to fail. The fortran compiler/ f2py setup on linux seems to be fine with this code and wheels build fine already. 

This results in errors such as 
```
In: :solid:src/pysolid/solid.for:detide
        vars2fortran: No typespec for argument "mjd".
```