### PR TITLE
setup: roll back configs except for version and download_url

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: "github-actions"      # see doc for possible values
+    directory: "/"                           # location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,46 @@
 import setuptools
 from numpy.distutils.core import setup, Extension
 
+# read the contents of README file
+def readme():
+    with open("README.md") as f:
+        return f.read()
+
 setup(
     ## add the following redundant setup for setuptools<60, the latter is required for numpy.distutils
-    name='pysolid',
+    name="pysolid",
+    description="A Python wrapper for solid to compute solid Earth tides",
+    url="https://github.com/insarlab/PySolid",
+    long_description=readme(),
+    long_description_content_type="text/markdown",
+    author="Zhang Yunjun, Dennis Milbert",
+    author_email="yunjunzgeo@gmail.com",
+    license="GPL-3.0-or-later",
+    license_files=("LICENSE",),
+
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+    ],
+    keywords="solid Eartth tides, deformation, geodesy, geophysics",
+
+    project_urls={
+        "Bug Reports": "https://github.com/insarlab/PySolid/issues",
+        "Source": "https://github.com/insarlab/PySolid",
+    },
+
+    # dependencies
+    python_requires=">=3.8",
+    install_requires=[
+        "numpy",
+        "scipy",
+        "matplotlib",
+        "scikit-image",
+    ],
 
     # package discovery
     packages=setuptools.find_packages("src"),  # include all packages under src
@@ -21,6 +58,6 @@ setup(
 
     ## fortran extensions to build with numpy.f2py
     ext_modules=[
-        Extension(name='pysolid.solid', sources=['src/pysolid/solid.for']),
+        Extension(name="pysolid.solid", sources=["src/pysolid/solid.for"]),
     ],
 )


### PR DESCRIPTION
+ setup: roll back configs except for version and download_url, after checking the current test pypi page for version 0.2.3.post4 (https://test.pypi.org/project/pysolid/0.2.3.post4/)

+ .github/dependabot: change the interval from daily to weekly