### PR TITLE
dep: drop matplotlib

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           command: |
             export PYTHONUNBUFFERED=1
             # install dependencies and source code
-            mamba install --verbose --yes  fortran-compiler --file ${PYSOLID_HOME}/requirements.txt
+            mamba install --verbose --yes  fortran-compiler --file ${PYSOLID_HOME}/requirements.txt --file ${PYSOLID_HOME}/tests/requirements.txt
             python -m pip install ${PYSOLID_HOME}
 
       - run:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+# extra dependencies required for running notebooks
+cartopy
+matplotlib
+mintpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers=[
 dependencies = [
     "numpy",
     "scipy",
-    "matplotlib",
 ]
 dynamic = ["version"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # for running
 numpy
 scipy
-matplotlib
 # for packaging and installation
 #fortran-compiler   # Fortran compiler across platforms through conda-forge channel
 pip

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
     install_requires=[
         "numpy",
         "scipy",
-        "matplotlib",
     ],
 
     # package discovery

--- a/src/pysolid/point.py
+++ b/src/pysolid/point.py
@@ -16,8 +16,6 @@ import datetime as dt
 import os
 
 import numpy as np
-from matplotlib import pyplot as plt, ticker, dates as mdates
-from scipy import signal
 
 
 ## Tidal constituents
@@ -94,10 +92,10 @@ def calc_solid_earth_tides_point(lat, lon, dt0, dt1, step_sec=60, display=False,
     """
 
     print('PYSOLID: calculate solid Earth tides in east/north/up direction')
-    print('PYSOLID: lot/lon: {}/{} degree'.format(lat, lon))
-    print('PYSOLID: start UTC: {}'.format(dt0.isoformat()))
-    print('PYSOLID: end   UTC: {}'.format(dt1.isoformat()))
-    print('PYSOLID: time step: {} seconds'.format(step_sec))
+    print(f'PYSOLID: lot/lon: {lat}/{lon} degree')
+    print(f'PYSOLID: start UTC: {dt0.isoformat()}')
+    print(f'PYSOLID: end   UTC: {dt1.isoformat()}')
+    print(f'PYSOLID: time step: {step_sec} seconds')
 
     dt_out = []
     tide_e = []
@@ -108,7 +106,7 @@ def calc_solid_earth_tides_point(lat, lon, dt0, dt1, step_sec=60, display=False,
     for i in range(ndays):
         di = dt0.date() + dt.timedelta(days=i)
         if verbose:
-            print('SOLID  : {} {}/{} ...'.format(di.isoformat(), i+1, ndays))
+            print(f'SOLID  : {di.isoformat()} {i+1}/{ndays} ...')
 
         # calc tide_u/n/u for the whole day
         (dt_outi,
@@ -185,6 +183,8 @@ def calc_solid_earth_tides_point_per_day(lat, lon, date_str, step_sec=60):
 def plot_solid_earth_tides_point(dt_out, tide_e, tide_n, tide_u, lalo=None,
                                  out_fig=None, save=False, display=True):
     """Plot the solid Earth tides at one point."""
+    from matplotlib import pyplot as plt, dates as mdates
+
     # plot
     fig, axs = plt.subplots(nrows=3, ncols=1, figsize=[6, 4], sharex=True)
     for ax, data, label in zip(axs.flatten(),
@@ -227,6 +227,9 @@ def plot_power_spectral_density4tides(tide_ts, sample_spacing, out_fig=None, fig
     """Plot the power spectral density (PSD) of tides time-series.
     Note: for accurate PSD analysis, a long time-series, e.g. one year, is recommended.
     """
+    from matplotlib import pyplot as plt, ticker
+    from scipy import signal
+
     ## calc PSD
     freq, psd = signal.periodogram(tide_ts, fs=1/sample_spacing, scaling='density')
     # get rid of zero in the first element

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+# extra dependency required for testing
+matplotlib


### PR DESCRIPTION
+ remove matplotlib from the dependency list, as it's not needed in the actual SET calculation, but for result plotting and inspection only, as described in #67.
   - remove matplotlib in `pyproject.toml`, `requirements.txt` and `setup.py` files
   - `point`: move the module import of matplotlib from top of the script to inside the functions.

+ add `docs/requirements.txt` for extra dependencies needed for running notebooks

+ add `tests/requirements.txt` for extra dependencies needed for running tests

After this PR, we could cut for a maintenance release version 0.3.1 to update the conda-forge recipe.