### PR TITLE
`pyproject.toml`: add dynamic requirements from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ git clone https://github.com/insarlab/PySolid.git
 
 ```bash
 # option 1: use conda to install dependencies into an existing, activated environment
-conda install -c conda-forge fortran-compiler --file PySolid/requirements.txt
+conda install -c conda-forge fortran-compiler --file PySolid/requirements.txt --file PySolid/tests/requirements.txt
 
 # option 2: use conda to install dependencies into a new environment, e.g. named "pysolid"
-conda create --name pysolid fortran-compiler --file PySolid/requirements.txt
+conda create --name pysolid fortran-compiler --file PySolid/requirements.txt --file PySolid/tests/requirements.txt
 conda activate pysolid
 
 # option 3: have a Fortran compiler already installed and use pip to install the rest dependencies
-python -m pip install -r PySolid/requirements.txt
+python -m pip install -r PySolid/requirements.txt -r PySolid/tests/requirements.txt
 ```
 
 ##### c. Install PySolid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ zip-safe = false
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
 
-# extra requirements: `pip install pydolid[docs]` or `pip install .[docs,test]`
+# extra requirements: `pip install pysolid[docs]` or `pip install .[docs,test]`
 [tool.setuptools.dynamic.optional-dependencies.docs]
 file = ["docs/requirements.txt"]
 [tool.setuptools.dynamic.optional-dependencies.test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 keywords = ["solid Earth tides", "deformation", "geodesy", "geophysics"]
 license = {text = "GPL-3.0-or-later"}
-classifiers=[
+classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering",
@@ -21,11 +21,11 @@ classifiers=[
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
 ]
-dependencies = [
-    "numpy",
-    "scipy",
-]
-dynamic = ["version"]
+
+# see section: setuptools_scm
+# https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata
+# dependencies will be read from text files
+dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [project.urls]
 "Homepage" = "https://github.com/insarlab/PySolid"
@@ -34,6 +34,15 @@ dynamic = ["version"]
 [tool.setuptools]
 include-package-data = true
 zip-safe = false
+
+[tool.setuptools.dynamic]
+dependencies = { file = ["requirements.txt"] }
+
+# extra requirements: `pip install pydolid[docs]` or `pip install .[docs,test]`
+[tool.setuptools.dynamic.optional-dependencies.docs]
+file = ["docs/requirements.txt"]
+[tool.setuptools.dynamic.optional-dependencies.test]
+file = ["tests/requirements.txt"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ zip-safe = false
 dependencies = { file = ["requirements.txt"] }
 
 # extra requirements: `pip install pysolid[docs]` or `pip install .[docs,test]`
+# note: the [docs] syntax requires setuptools>=64.0, thus, not working yet.
 [tool.setuptools.dynamic.optional-dependencies.docs]
 file = ["docs/requirements.txt"]
 [tool.setuptools.dynamic.optional-dependencies.test]


### PR DESCRIPTION
Testing out the dynamic requirements, we'll see if the build works alright with the `"setuptools<60.0"` pin.