### PR TITLE
move packaging and installation requirements to tests/requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,3 @@
 # for running
 numpy
 scipy
-# for packaging and installation
-#fortran-compiler   # Fortran compiler across platforms through conda-forge channel
-pip
-setuptools
-setuptools_scm
-wheel

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,8 @@
+# for packaging and installation
+#fortran-compiler   # Fortran compiler across platforms through conda-forge channel
+pip
+setuptools
+setuptools_scm
+wheel
 # extra dependency required for testing
 matplotlib


### PR DESCRIPTION
@yunjunz this will fix #76, and shouldn't require any docs or CI/CD changes. 

Basically, this:
* changes `requirements.txt` to be runtime dependencies only
* changes `tests/requirements.txt` to be all additional dependencies for *development* (building, packaging, testing)

which is *fine* overall and coherent with the docs. 

Strictly speaking, I don't think you need to list `setuptools`, `setuptools_scm`, or `wheel` as development dependencies as `pip` will do isolated builds if a `pyproject.toml` is present and pull the build dependencies from the `[build-system]` requirements listed there. 

But, I do like having `setuptools_scm` in the dev environment so I can easily check what version it thinks the project is on with:
```
python -m setuptools_scm
```

If you're going to keep them, however, it's probably worth including the same pins in the `requirements.txt` files as `pyproject.toml`:
```yaml
requires = ["setuptools<60.0", "setuptools_scm[toml]>=6.2", "numpy<1.23.0", "wheel"]
```