### PR TITLE
pub2pypi: fix unknow dist format error

### DIFF
--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -85,16 +85,19 @@ jobs:
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir
-          pattern: artifact-*
           path: dist
+          pattern: artifact-*
+          merge-multiple: true
+      - name: Display structure of downloaded files
+        run: ls -R dist
 
       - name: Publish developed version 📦 to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: false
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: false
           verbose: true
 
       - name: Publish released version 📦 to PyPI

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is research code provided to you "as is" with NO WARRANTIES OF CORRECTNESS.
 
 ### 1. Install
 
-PySolid is available on the [conda-forge](https://anaconda.org/conda-forge/pysolid) channel and the main archive of the [Debian](https://tracker.debian.org/pkg/pysolid) GNU/Linux OS. The released version can be install via `conda` as:
+PySolid is available on the [conda-forge](https://anaconda.org/conda-forge/pysolid) channel and the main archive of the [Debian](https://tracker.debian.org/pkg/pysolid) GNU/Linux OS. The released version can be installed via `conda` as:
 
 ```shell
 # run "conda update pysolid" to update the installed version


### PR DESCRIPTION
+ fix the following error (https://github.com/insarlab/PySolid/actions/runs/7326479653/job/19952659672) by turning on the `merge-multiple` option, as suggested by download-artifact readme

   - Checking dist/artifact-source: ERROR InvalidDistribution: Unknown distribution format: 'artifact-source'

+ display the structure of downloaded artifact files, to facilitate the debuging in the future, since this part is easy to have issues

+ update deprecated option names in gh-action-pypi-publish

+ README: fix typo