### PR TITLE
replace `numpy.distutils` with `CMake` and `scikit-build-core` build backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
     # The executor is the environment in which the steps below will be executed - below will use a python 3.9 container
     # Change the version below to your required version of python
     docker:
-      - image: ubuntu:bionic
+      - image: cimg/base:current
         environment:
           CONDA_PREFIX: /root/tools/miniforge
           PYSOLID_HOME: /root/tools/PySolid

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Scikit-build temp directory
+/_skbuild/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Based on:
+# https://github.com/scikit-build/scikit-build-core/tree/main/docs/examples/getting_started/fortran
+
+cmake_minimum_required(VERSION 3.17.2...3.29)
+project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
+
+find_package(
+  Python
+  COMPONENTS Interpreter Development.Module NumPy
+  REQUIRED)
+
+# F2PY headers
+execute_process(
+  COMMAND "${PYTHON_EXECUTABLE}" -c
+          "import numpy.f2py; print(numpy.f2py.get_include())"
+  OUTPUT_VARIABLE F2PY_INCLUDE_DIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+add_library(fortranobject OBJECT "${F2PY_INCLUDE_DIR}/fortranobject.c")
+target_link_libraries(fortranobject PUBLIC Python::NumPy)
+target_include_directories(fortranobject PUBLIC "${F2PY_INCLUDE_DIR}")
+set_property(TARGET fortranobject PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+add_custom_command(
+  OUTPUT solidmodule.c solid-f2pywrappers.f
+  DEPENDS src/pysolid/solid.for
+  VERBATIM
+  COMMAND "${Python_EXECUTABLE}" -m numpy.f2py
+          "${CMAKE_CURRENT_SOURCE_DIR}/src/pysolid/solid.for" -m solid --lower)
+
+python_add_library(
+  solid MODULE "${CMAKE_CURRENT_BINARY_DIR}/solidmodule.c"
+  "${CMAKE_CURRENT_BINARY_DIR}/solid-f2pywrappers.f"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/pysolid/solid.for" WITH_SOABI)
+target_link_libraries(solid PRIVATE fortranobject)
+
+install(TARGETS solid DESTINATION pysolid)

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ python -m pip install -r PySolid/requirements.txt -r PySolid/tests/requirements.
 python -m pip install PySolid
 
 # option 2: use pip to install pysolid in develop mode (editable) into the current environment
-# setting an environmental variable as below is required for editable installs via pyproject.toml
-export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
 python -m pip install -e PySolid
 
 # option 3: manually compile the Fortran code and setup environment variable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm[toml]>=6.2", "numpy", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["cmake", "scikit-build-core", "setuptools", "setuptools_scm[toml]>=6.2", "numpy", "wheel"]
+build-backend = "scikit_build_core.build"
 
 [project]
 name = "pysolid"
@@ -54,3 +54,6 @@ pysolid = ["*.for"]
 [tool.setuptools_scm]
 version_scheme = "post-release"
 local_scheme = "no-local-version"
+
+[tool.scikit-build]
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<60.0", "setuptools_scm[toml]>=6.2", "numpy<1.23.0", "wheel"]
+requires = ["setuptools", "setuptools_scm[toml]>=6.2", "numpy", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,38 @@
 
 # always prefer setuptools over distutils
 import setuptools
-from numpy.distutils.core import setup, Extension
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+from numpy import f2py
+import os
+import subprocess
+import sys
 
 # read the contents of README file
 def readme():
     with open("README.md") as f:
         return f.read()
+
+class f2py_build(build_ext):
+    def run(self):
+        for ext in self.extensions:
+            self.build_extension(ext)
+
+    def build_extension(self, ext):
+        # Reuse setuptools build_ext logic for output location and name
+        build_dir, fname = os.path.split(super().get_ext_fullpath(ext.name))
+        module = fname.split(".")[0]
+
+        # Compile a Fortran module using f2py
+        c = [sys.executable, "-m", "numpy.f2py", "-c"]
+        # Specify module name and source file paths
+        c += ["-m", module] + [os.path.abspath(x) for x in ext.sources]
+        # Use meson backend (enforces python 3.12+ behavior, not needed)
+        #c += ["--backend", "meson"]
+
+        # No way to specify the output location,
+        # so we have to run with CWD as the destination directory
+        subprocess.run(c, cwd=build_dir)
 
 setup(
     ## add the following redundant setup for setuptools<60, the latter is required for numpy.distutils
@@ -58,4 +84,6 @@ setup(
     ext_modules=[
         Extension(name="pysolid.solid", sources=["src/pysolid/solid.for"])
     ],
+
+    cmdclass=dict(build_ext=f2py_build),
 )

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,7 @@
 
 # always prefer setuptools over distutils
 import setuptools
-from setuptools import setup, Extension
-from setuptools.command.build_ext import build_ext
-from numpy import f2py
+from skbuild import setup
 import os
 import subprocess
 import sys
@@ -14,27 +12,6 @@ import sys
 def readme():
     with open("README.md") as f:
         return f.read()
-
-class f2py_build(build_ext):
-    def run(self):
-        for ext in self.extensions:
-            self.build_extension(ext)
-
-    def build_extension(self, ext):
-        # Reuse setuptools build_ext logic for output location and name
-        build_dir, fname = os.path.split(super().get_ext_fullpath(ext.name))
-        module = fname.split(".")[0]
-
-        # Compile a Fortran module using f2py
-        c = [sys.executable, "-m", "numpy.f2py", "-c"]
-        # Specify module name and source file paths
-        c += ["-m", module] + [os.path.abspath(x) for x in ext.sources]
-        # Use meson backend (enforces python 3.12+ behavior, not needed)
-        #c += ["--backend", "meson"]
-
-        # No way to specify the output location,
-        # so we have to run with CWD as the destination directory
-        subprocess.run(c, cwd=build_dir)
 
 setup(
     ## add the following redundant setup for setuptools<60, the latter is required for numpy.distutils
@@ -79,11 +56,4 @@ setup(
     package_data={
         "pysolid": ["solid.for"],
     },
-
-    ## fortran extensions to build with numpy.f2py
-    ext_modules=[
-        Extension(name="pysolid.solid", sources=["src/pysolid/solid.for"])
-    ],
-
-    cmdclass=dict(build_ext=f2py_build),
 )

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,6 @@
 # always prefer setuptools over distutils
 import setuptools
 from skbuild import setup
-import os
-import subprocess
-import sys
 
 # read the contents of README file
 def readme():

--- a/src/pysolid/point.py
+++ b/src/pysolid/point.py
@@ -62,7 +62,7 @@ TIDES = (
     Tag('Shallow water terdiurnal'                  , r'$MK_3$'     , 8.177140247,  44.0251729, 365.555, 8 ),
     Tag('Shallow water overtides of principal solar', r'$S_4$'      , 6.0        ,  60.0      , 491.555, 9 ),
     Tag('Shallow water quarter diurnal'             , r'$MN_4$'     , 6.269173724,  57.4238337, 445.655, 10),
-    Tag('Shallow water overtides of principal solar', r'$S_6$'      , 4.0        ,  90.0      , np.NaN , 12),
+    Tag('Shallow water overtides of principal solar', r'$S_6$'      , 4.0        ,  90.0      , np.nan , 12),
     Tag('Lunar terdiurnal'                          , r'$M_3$'      , 8.280400802,  43.4761563, 355.555, 32),
     Tag('Shallow water terdiurnal'                  , '2"MK'+r'$_3$', 8.38630265 ,  42.9271398, 345.555, 34),
     Tag('Shallow water eighth diurnal'              , r'$M_8$'      , 3.105150301, 115.9364166, 855.555, 36),

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 # for packaging and installation
 #fortran-compiler   # Fortran compiler across platforms through conda-forge channel
+meson
 pip
 setuptools_scm>=6.2
 # for testing


### PR DESCRIPTION
As setuptools cannot natively call f2py, we call it ourselves by using a custom build extension.

Closes https://github.com/insarlab/PySolid/issues/78

(This seemed like the simplest way to do things - keep using setuptools, and have it manually call f2py under the hood.)