### PR TITLE
`pyproject.toml`: use static metadata for readme/dependencies

### DIFF
--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -18,37 +18,38 @@ jobs:
       matrix:
         # skip building wheel for windows as it's not working yet
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, macos-latest, macos-13, macos-14]  #windows-2019
+        os: [ubuntu-latest, macos-13, macos-14]  #windows-2019
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Fortran
-        uses: fortran-lang/setup-fortran@v1
-        if: ${{ runner.os == 'macOS' }}
-        with:
-            compiler: gfortran
+      - name: Provide gfortran (macOS-13)
+        if: matrix.os == 'macos-13'
+        run: |
+          # https://github.com/actions/virtual-environments/issues/2524
+          # https://github.com/cbg-ethz/dce/blob/master/.github/workflows/pkgdown.yaml
+          sudo ln -s /usr/local/bin/gfortran-13 /usr/local/bin/gfortran
+          sudo mkdir /usr/local/gfortran
+          sudo ln -s /usr/local/Cellar/gcc@13/*/lib/gcc/13 /usr/local/gfortran/lib
+          gfortran --version
 
-      #- name: Provide gfortran (macOS)
-      #  if: runner.os == 'macOS'
-      #  run: |
-      #    # https://github.com/actions/virtual-environments/issues/2524
-      #    # https://github.com/cbg-ethz/dce/blob/master/.github/workflows/pkgdown.yaml
-      #    sudo ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
-      #    sudo mkdir /usr/local/gfortran
-      #    sudo ln -s /usr/local/Cellar/gcc@11/*/lib/gcc/11 /usr/local/gfortran/lib
-      #    gfortran --version
+        - name: Provide gfortran (macOS-14)
+        if: matrix.os == 'macos-14'
+        run: |
+          # https://fortran-lang.discourse.group/t/fortran-lang-setup-fortran-support-macos-with-apple-silicon-chips/7427
+          sudo ln -s $(which gfortran-${{ matrix.version }}) $(dirname $(which gfortran-${{ matrix.version }}))/gfortran                                                                                 
+          which gfortran && gfortran --version
 
-      #- name: Provide gfortran (Windows)
-      #  if: runner.os == 'Windows'
-      #  uses: msys2/setup-msys2@v2
+      - name: Provide gfortran (Windows)
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
 
-      #- name: Tell distutils to use mingw (Windows)
-      #  if: runner.os == 'Windows'
-      #  run: |
-      #    echo "[build]`ncompiler=mingw32" | Out-File -Encoding ASCII ~/pydistutils.cfg
+      - name: Tell distutils to use mingw (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo "[build]`ncompiler=mingw32" | Out-File -Encoding ASCII ~/pydistutils.cfg
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.14.1

--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -18,7 +18,20 @@ jobs:
       matrix:
         # skip building wheel for windows as it's not working yet
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13, macos-14]  #windows-2019
+        os: [ubuntu-latest, macos-latest, macos-13, macos-14]  #windows-2019
+        toolchain:
+          - {compiler: gcc, version: 13}
+          - {compiler: intel, version: '2023.2'}
+          - {compiler: intel-classic, version: '2021.10'}
+          - {compiler: nvidia-hpc, version: '23.11'}
+        include:
+          - os: ubuntu-latest
+            toolchain: {compiler: gcc, version: 12}
+        exclude:
+          - os: macos-latest
+            toolchain: {compiler: intel, version: '2023.2'}
+          - os: macos-latest
+            toolchain: {compiler: nvidia-hpc, version: '23.11'}
 
     steps:
       - uses: actions/checkout@v4
@@ -26,10 +39,14 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Fortran
-        uses: fortran-lang/setup-fortran@main
+        uses: fortran-lang/setup-fortran@v1
+        id: setup-fortran
         with:
-            compiler: ${{ matrix.compiler }}
-            version: ${{ matrix.version }}
+            compiler: ${{ matrix.toolchain.compiler }}
+            version: ${{ matrix.toolchain.version }}
+        - run: |
+          ${{ env.FC }} --version # environment vars FC, CC, and CXX are set
+          #${{ steps.setup-fortran.outputs.fc }} ... # outputs work too
 
       #- name: Provide gfortran (macOS)
       #  if: runner.os == 'macOS'

--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -19,11 +19,6 @@ jobs:
         # skip building wheel for windows as it's not working yet
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, macos-latest, macos-13, macos-14]  #windows-2019
-        toolchain:
-          - {compiler: gcc, version: 13}
-        include:
-          - os: ubuntu-latest
-            toolchain: {compiler: gcc, version: 12}
 
     steps:
       - uses: actions/checkout@v4
@@ -32,10 +27,10 @@ jobs:
 
       - name: Set up Fortran
         uses: fortran-lang/setup-fortran@v1
-        id: setup-fortran
+        if: ${{ runner.os == 'macOS' }}
         with:
-            compiler: ${{ matrix.compiler }}
-            version: ${{ matrix.version }}
+            compiler: gfortran
+        run: gfortran --version
 
       #- name: Provide gfortran (macOS)
       #  if: runner.os == 'macOS'

--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -34,8 +34,8 @@ jobs:
         uses: fortran-lang/setup-fortran@v1
         id: setup-fortran
         with:
-            compiler: ${{ matrix.toolchain.compiler }}
-            version: ${{ matrix.toolchain.version }}
+            compiler: ${{ matrix.compiler }}
+            version: ${{ matrix.version }}
 
       #- name: Provide gfortran (macOS)
       #  if: runner.os == 'macOS'

--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -16,7 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11]  #windows-2019
+        # skip building wheel for windows as it's not working yet
+        # macos-13 is an intel runner, macos-14 is apple silicon
+        os: [ubuntu-latest, macos-13, macos-14]  #windows-2019
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -17,8 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         # skip building wheel for windows as it's not working yet
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, macos-13, macos-14]  #windows-2019
+        os: [ubuntu-latest, macos-13]  #windows-2019
 
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Provide gfortran (macOS-13)
-        if: matrix.os == 'macos-13'
+        if: runner.os == 'macOS'
         run: |
           # https://github.com/actions/virtual-environments/issues/2524
           # https://github.com/cbg-ethz/dce/blob/master/.github/workflows/pkgdown.yaml
@@ -34,13 +33,6 @@ jobs:
           sudo mkdir /usr/local/gfortran
           sudo ln -s /usr/local/Cellar/gcc@13/*/lib/gcc/13 /usr/local/gfortran/lib
           gfortran --version
-
-        - name: Provide gfortran (macOS-14)
-        if: matrix.os == 'macos-14'
-        run: |
-          # https://fortran-lang.discourse.group/t/fortran-lang-setup-fortran-support-macos-with-apple-silicon-chips/7427
-          sudo ln -s $(which gfortran-${{ matrix.version }}) $(dirname $(which gfortran-${{ matrix.version }}))/gfortran                                                                                 
-          which gfortran && gfortran --version
 
       - name: Provide gfortran (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -30,7 +30,6 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         with:
             compiler: gfortran
-        run: gfortran --version
 
       #- name: Provide gfortran (macOS)
       #  if: runner.os == 'macOS'

--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -18,31 +18,37 @@ jobs:
       matrix:
         # skip building wheel for windows as it's not working yet
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, macos-13, macos-14]  #windows-2019
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13, macos-14]  #windows-2019
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Provide gfortran (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          # https://github.com/actions/virtual-environments/issues/2524
-          # https://github.com/cbg-ethz/dce/blob/master/.github/workflows/pkgdown.yaml
-          sudo ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
-          sudo mkdir /usr/local/gfortran
-          sudo ln -s /usr/local/Cellar/gcc@11/*/lib/gcc/11 /usr/local/gfortran/lib
-          gfortran --version
+      - name: Set up Fortran
+        uses: fortran-lang/setup-fortran@main
+        with:
+            compiler: ${{ matrix.compiler }}
+            version: ${{ matrix.version }}
 
-      - name: Provide gfortran (Windows)
-        if: runner.os == 'Windows'
-        uses: msys2/setup-msys2@v2
+      #- name: Provide gfortran (macOS)
+      #  if: runner.os == 'macOS'
+      #  run: |
+      #    # https://github.com/actions/virtual-environments/issues/2524
+      #    # https://github.com/cbg-ethz/dce/blob/master/.github/workflows/pkgdown.yaml
+      #    sudo ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
+      #    sudo mkdir /usr/local/gfortran
+      #    sudo ln -s /usr/local/Cellar/gcc@11/*/lib/gcc/11 /usr/local/gfortran/lib
+      #    gfortran --version
 
-      - name: Tell distutils to use mingw (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          echo "[build]`ncompiler=mingw32" | Out-File -Encoding ASCII ~/pydistutils.cfg
+      #- name: Provide gfortran (Windows)
+      #  if: runner.os == 'Windows'
+      #  uses: msys2/setup-msys2@v2
+
+      #- name: Tell distutils to use mingw (Windows)
+      #  if: runner.os == 'Windows'
+      #  run: |
+      #    echo "[build]`ncompiler=mingw32" | Out-File -Encoding ASCII ~/pydistutils.cfg
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.14.1

--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -21,17 +21,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, macos-13, macos-14]  #windows-2019
         toolchain:
           - {compiler: gcc, version: 13}
-          - {compiler: intel, version: '2023.2'}
-          - {compiler: intel-classic, version: '2021.10'}
-          - {compiler: nvidia-hpc, version: '23.11'}
         include:
           - os: ubuntu-latest
             toolchain: {compiler: gcc, version: 12}
-        exclude:
-          - os: macos-latest
-            toolchain: {compiler: intel, version: '2023.2'}
-          - os: macos-latest
-            toolchain: {compiler: nvidia-hpc, version: '23.11'}
 
     steps:
       - uses: actions/checkout@v4
@@ -44,9 +36,6 @@ jobs:
         with:
             compiler: ${{ matrix.toolchain.compiler }}
             version: ${{ matrix.toolchain.version }}
-        - run: |
-          ${{ env.FC }} --version # environment vars FC, CC, and CXX are set
-          #${{ steps.setup-fortran.outputs.fc }} ... # outputs work too
 
       #- name: Provide gfortran (macOS)
       #  if: runner.os == 'macOS'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ authors = [
     {name="Zhang Yunjun", email="yunjunz@outlook.com"},
     {name="Dennis Milbert"},
 ]
+readme = "README.md"
 requires-python = ">=3.8"
+dependencies = [
+    "numpy",
+    "scipy",
+]
 
 keywords = ["solid Earth tides", "deformation", "geodesy", "geophysics"]
 license = {text = "GPL-3.0-or-later"}
@@ -25,7 +30,7 @@ classifiers = [
 # see section: setuptools_scm
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata
 # dependencies will be read from text files
-dynamic = ["version", "readme", "dependencies", "optional-dependencies"]
+dynamic = ["version"]
 
 [project.urls]
 "Homepage" = "https://github.com/insarlab/PySolid"
@@ -34,17 +39,6 @@ dynamic = ["version", "readme", "dependencies", "optional-dependencies"]
 [tool.setuptools]
 include-package-data = true
 zip-safe = false
-
-[tool.setuptools.dynamic]
-dependencies = { file = ["requirements.txt"] }
-readme = { file = "README.md", content-type = "text/markdown" }
-
-# extra requirements: `pip install pysolid[docs]` or `pip install .[docs,test]`
-# note: the [docs] syntax requires setuptools>=64.0, thus, not working yet.
-[tool.setuptools.dynamic.optional-dependencies.docs]
-file = ["docs/requirements.txt"]
-[tool.setuptools.dynamic.optional-dependencies.test]
-file = ["tests/requirements.txt"]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
+ pyproject.toml: for readme, dependencies, optional-dependencies, use static metadata, instead of dynamic ones, to avoid [the following errors](https://github.com/insarlab/PySolid/actions/runs/9625771487/job/26551314687):

```bash
ERROR    HTTPError: 400 Bad Request from https://test.pypi.org/legacy/
         ['readme', 'dependencies', 'optional-dependencies'] is not a valid dynamic field. See https://packaging.python.org/specifications/core-metadata for more information.
```

+ `build-and-publish-to-pypi.yml`: update OS versions
   - ubuntu: from 20.04 to latest
   - macos: from 11 to 13