### PR TITLE
turn OFF the mild warning msg of time cross leap second table 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ workflows:
     jobs:
       - build-and-test
 
-
 jobs:
   build-and-test:  # This is the name of the job, feel free to change it to better match what you're trying to do!
     # These next lines defines a Docker executors: https://circleci.com/docs/2.0/executor-types/
@@ -29,6 +28,8 @@ jobs:
           PYSOLID_HOME: /root/tools/PySolid
         user: root
     working_directory: /root/tools/PySolid
+    resource_class: medium
+
     # Checkout the code as the first step. This is a dedicated CircleCI step.
     steps:
       - checkout
@@ -36,14 +37,15 @@ jobs:
           name: Setting Environment with Miniforge
           command: |
             apt update
-            apt-get update --yes && apt-get upgrade --yes
+            apt-get update && apt-get upgrade --yes
             apt-get install --yes wget git
-            # download and install miniforge
+            # install miniforge (https://github.com/conda-forge/miniforge?tab=readme-ov-file#as-part-of-a-ci-pipeline)
             mkdir -p ${HOME}/tools
             cd ${HOME}/tools
-            wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
-            bash Miniforge3-Linux-x86_64.sh -b -p ${HOME}/tools/miniforge
-            ${HOME}/tools/miniforge/bin/mamba init bash
+            wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+            bash Miniforge3.sh -b -p ${HOME}/tools/miniforge
+            source "${HOME}/tools/miniforge/etc/profile.d/conda.sh"
+            source "${HOME}/tools/miniforge/etc/profile.d/mamba.sh"
             # modify/export env var PATH to BASH_ENV to be shared across run steps
             echo 'export PATH=${CONDA_PREFIX}/bin:${PATH}' >> ${BASH_ENV}
 

--- a/src/pysolid/solid.for
+++ b/src/pysolid/solid.for
@@ -154,7 +154,7 @@
 
 *** end of processing and flag for leap second
 
-      if(lflag) then
+      if(.false.) then
         print *, 'Mild Warning -- time crossed leap second table'
         print *, '  boundaries.  Boundary edge value used instead'
       endif
@@ -293,7 +293,7 @@
 
 *** end of processing and flag of leap second
 
-      if(lflag) then
+      if(.false.) then
         print *, 'Mild Warning -- time crossed leap second table'
         print *, '  boundaries.  Boundary edge value used instead'
       endif

--- a/tests/grid.py
+++ b/tests/grid.py
@@ -64,6 +64,7 @@ if __name__ == '__main__':
     assert np.allclose(tide_e[::80, ::100], tide_e_80_100)
     assert np.allclose(tide_n[::80, ::100], tide_n_80_100)
     assert np.allclose(tide_u[::80, ::100], tide_u_80_100)
+    print('Pass.')
 
     # plot
     out_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'pic'))

--- a/tests/point.py
+++ b/tests/point.py
@@ -63,6 +63,7 @@ if __name__ == '__main__':
     assert np.allclose(tide_e[::8000], tide_e_8000)
     assert np.allclose(tide_n[::8000], tide_n_8000)
     assert np.allclose(tide_u[::8000], tide_u_8000)
+    print('Pass.')
 
     # plot
     out_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'pic'))


### PR DESCRIPTION
This PR turns OFF the mild warning msg of time cross leap second table hardcored in `solid.for` because 1) no leap second has been introduced since Jan 2017 (https://data.iana.org/time-zones/tzdb/leap-seconds.list), and 2) the error introduced for missing a few  leap second is small, and the accuracy would still be enough for many applications (https://geodesyworld.github.io/SOFTS/solid.htm)

If there is new leap second announced by IERS, we will update the code accordingly.

## Summary by Sourcery

Disable leap-second boundary warning messages in the solid Earth tide Fortran routine and update CI Miniforge installation along with minor test output tweaks.

Bug Fixes:
- Suppress spurious leap-second boundary warnings by hard-disabling the associated Fortran flag in the solid tide computations.

Enhancements:
- Adjust CircleCI Miniforge installation to use platform-dynamic download URL and environment initialization scripts.
- Add simple success printouts to grid and point test scripts for clearer test feedback when run manually.

CI:
- Update CircleCI config to install Miniforge using an architecture-aware URL and conda/mamba initialization scripts.